### PR TITLE
Use forkIOWithUnmask

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -124,6 +124,11 @@ main =
         takeMVar ready
         killThread thread
         assertEqual "First finalizer is not slave" 0 =<< atomically (readTMVar var)
+    ,
+    testCase "Forked threads don't inherit the masking state" $ do
+      var <- newEmptyMVar
+      mask_ (S.fork (getMaskingState >>= putMVar var))
+      assertEqual "" Unmasked =<< takeMVar var
   ]
 
 forkWait :: IO a -> IO (IO ())


### PR DESCRIPTION
Hello again :)

This patch addresses the following concern: if `fork` is called with async exceptions _already masked_, then the forked thread will inherit this masking state, and `unmask` will be a no-op.

This code instead uses `forkIOWithUnmask`, which guarantees that the provided `unmask` function indeed unmasks.