### PR TITLE
Add 'link'

### DIFF
--- a/slave-thread.cabal
+++ b/slave-thread.cabal
@@ -76,6 +76,7 @@ library
   build-depends:
     base >=4.9 && <5,
     deferred-folds >=0.9 && <0.10,
+    focus >=1.0 && <1.1,
     foldl >=1 && <2,
     mmorph >=1.0.4 && <2,
     partial-handler >=1 && <2,


### PR DESCRIPTION
This patch adds a `link` function, which links the current thread to the given master.

I'm not really sure this is even wanted still, I was just going through old issues, so here's a patch if you'd like :)