### PR TITLE
Revert forkIO -> forkIOWithUnmask

### DIFF
--- a/library/SlaveThread/Util/LowLevelForking.hs
+++ b/library/SlaveThread/Util/LowLevelForking.hs
@@ -8,13 +8,5 @@ import SlaveThread.Prelude
 -- which does not install a default exception handler on the forked thread.
 {-# INLINE forkIOWithoutHandler #-}
 forkIOWithoutHandler :: IO () -> IO ThreadId
-forkIOWithoutHandler action = 
+forkIOWithoutHandler action =
   IO $ \s -> case (fork# action s) of (# s', tid #) -> (# s', ThreadId tid #)
-
--- |
--- A more efficient version of 'forkIOWithUnmask',
--- which does not install a default exception handler on the forked thread.
-{-# INLINE forkIOWithUnmaskWithoutHandler #-}
-forkIOWithUnmaskWithoutHandler :: ((forall a. IO a -> IO a) -> IO ()) -> IO ThreadId
-forkIOWithUnmaskWithoutHandler action =
-  forkIOWithoutHandler (action unsafeUnmask)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -124,11 +124,6 @@ main =
         killThread thread
         assertEqual "First finalizer is not slave" 0 =<< atomically (readTMVar var)
     ,
-    testCase "Forked threads don't inherit the masking state" $ do
-      var <- newEmptyMVar
-      mask_ (S.fork (getMaskingState >>= putMVar var))
-      assertEqual "" Unmasked =<< takeMVar var
-    ,
     testCase "Slave thread finalizer is not interrupted by its own death (#11)" $ do
       -- Set up the ref that should be written to by thread 2's finalizer,
       -- otherwise there's a bug.


### PR DESCRIPTION
This patch fixes #16, which reverts #6, and also exports `fork(Finally)WithUnmask` variants.

I've also added a big `Note` that explains how these unmasking functions relate to those from base/async. Feel free to change the verbiage and whatnot, I just wanted to get something down as it's a bit subtle :)